### PR TITLE
display text on bar

### DIFF
--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -4,6 +4,7 @@
                     <div class="rounded-lg p-1 progbar" 
                       style="height:16px;clear:both;" 
                       :style="{ background: setBarColor(field.value), width: field.value + '%'}">
+                        <div style="position:relative;bottom:.1rem" class="font-bold text-xs text-center text-white">{{ field.text }}</div>
                     </div>
                 </template>
             </panel-item>

--- a/resources/js/components/IndexField.vue
+++ b/resources/js/components/IndexField.vue
@@ -1,9 +1,10 @@
 <template>
     <div class="flex">
             <div class="rounded-lg" style="height:16px;width:100%;background-color: #f1f5f8;">
-                <div class="rounded-lg p-1 progbar" 
+                <div class="rounded-lg p-1 progbar"
                  style="height:16px;clear:both;" 
                  :style="{ background: setBarColor(field.value), width: field.value + '%'}">
+                    <div style="position:relative;bottom:.1rem" class="font-bold text-xs text-center text-white">{{ field.text }}</div>
                 </div>
             </div>
     </div>

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -12,4 +12,17 @@ class ProgressBar extends Field
      * @var string
      */
     public $component = 'progress-bar';
+
+    /**
+     * Write some text to be displayed on the bar.
+     *
+     * @param  string  $text
+     * @return $this
+     */
+    public function text(string $text)
+    {
+        return $this->withMeta([
+            'text' => $text
+        ]);
+    }
 }


### PR DESCRIPTION
This allows the developer to display some text on the bar.

```
ProgressBar::make('Progress')->text($this->progress.'%'),
```

Looks like this:

<img width="814" alt="Screen Shot 2019-07-26 at 2 06 37 PM" src="https://user-images.githubusercontent.com/33736292/61972085-acd01880-afae-11e9-9026-566ccf1b2386.png">

For now I made the text centered, white, and bolded.

I didn't commit the compiled JavaScript in either this or my previous PR since there's no lock file in the repo.
